### PR TITLE
Creating weapon mastery medal names dictionary

### DIFF
--- a/dictionaries/weaponMastery/medalName.json
+++ b/dictionaries/weaponMastery/medalName.json
@@ -1,0 +1,14 @@
+{
+  "MedalAnnihiliation": "Annihilation",
+  "MedalAssassin": "Assassin",
+  "MedalDeadeye": "Deadeye",
+  "MedalDoubleKill": "Double Kill",
+  "MedalFirstblood": "First Blood",
+  "MedalFrenzy": "Frenzy",
+  "MedalLastManStanding": "Last Man Standing",
+  "MedalLongshot": "Longshot",
+  "MedalPunisher": "Punisher",
+  "MedalQuadKill": "Quad Kill",
+  "MedalRampage": "Rampage",
+  "MedalTripleKill": "Triple Kill"
+}


### PR DESCRIPTION
This adds a new folder to the /dictionaries directory for weaponMastery.  A single new file has been added for "medalNames.json" to provide names for the medal ids provided in weapon mastery.